### PR TITLE
Create project on 1 step & redirect

### DIFF
--- a/src/projects/components/parts/project-form/ProjectForm.tsx
+++ b/src/projects/components/parts/project-form/ProjectForm.tsx
@@ -8,9 +8,10 @@ import { notifications } from '@mantine/notifications';
 type ProjectFormProps = {
     project: Project;
     onProjectChange: (p: Project) => void;
+    avoidSave: Boolean;
 };
 
-export function ProjectForm({ project, onProjectChange }: ProjectFormProps) {
+export function ProjectForm({ project, onProjectChange, avoidSave = false }: ProjectFormProps) {
     const { local_backend } = useContext(SettingsContext);
     const [{ data, loading, error }, executeSave] = useAxios(
         {
@@ -28,6 +29,12 @@ export function ProjectForm({ project, onProjectChange }: ProjectFormProps) {
         },
     });
     const onSave = (project: Project) => {
+        // TODO: ugly temporal. We probably should refactor this a bit more.
+        if (avoidSave) {
+            onProjectChange(project);
+            return;
+        }
+
         executeSave({
             url: `${local_backend}/projects/${project.uuid}`,
             data: {

--- a/src/projects/components/projects-page/parts/create-project/CreateProject.tsx
+++ b/src/projects/components/projects-page/parts/create-project/CreateProject.tsx
@@ -1,15 +1,29 @@
 import {Container, Group, rem, Stepper, Text} from '@mantine/core';
 import {useContext, useEffect, useState} from "react";
+import { useNavigate } from "react-router-dom";
 import {Dropzone} from "@mantine/dropzone";
 import {IconPhoto, IconUpload, IconX} from "@tabler/icons-react";
 import useAxios from "axios-hooks";
 import {ProjectForm} from "@/projects/components/parts/project-form/ProjectForm";
 import {Project} from "@/projects/entities/Project.ts";
 import { SettingsContext } from '@/core/utils/settingsContext.ts';
+import { notifications } from '@mantine/notifications';
 
 export function CreateProject() {
     const {local_backend} = useContext(SettingsContext);
-    const [active, setActive] = useState(0);
+    const navigate = useNavigate();
+    const [files, setFiles] = useState<File[]>([]);
+    const emptyProject: Project = {
+        uuid: "",
+        name: "Project Name",
+        description: "",
+        path: "projectPath",
+        external_link: "",
+        tags: [],
+        default_image_path: "",
+        initialized: false,
+        assets: []
+    };
     const [{data, loading: saving, error}, executeSave] = useAxios(
         {
             url: `${local_backend}/projects`,
@@ -17,78 +31,73 @@ export function CreateProject() {
         },
         {manual: true}
     )
-    const [{data: project, loading: lProject, error: eProject}, loadProject] = useAxios(
-        `${local_backend}/projects/xx`,
-        {manual: true}
-    )
 
     const onDrop = (files: File[]) => {
         console.log(files);
-        const formData = new FormData();
-        formData.append("project", "new");
-        files.forEach((file) => formData.append("files", file));
-        executeSave({data: formData});
+        setFiles(files)
     };
 
     const onSave = (project: Project) => {
         console.log(project)
-        nextStep();
+
+        const formData = new FormData();
+        formData.append("project", "new");
+        formData.append("payload", JSON.stringify(project))
+        files.forEach((file) => formData.append("files", file));
+
+        executeSave({data: formData}).then((data) => {
+            if (!data.data.uuid) {
+                throw Error("UUID not provided in response")
+            }
+
+            navigate(`/projects/${data.data.uuid}`)
+        })
+        .catch(({ message }) => {
+            console.log(message)
+            notifications.show({
+                title: 'Ops... Error creating project!',
+                message,
+                color: 'red',
+                autoClose: false
+            })
+        });;
     }
-
-    useEffect(() => {
-        if (!data) return;
-        loadProject({url: `${local_backend}/projects/${data.uuid}`}).then(() => nextStep());
-    }, [data]);
-
-    const nextStep = () =>
-        setActive((current) => {
-            return current < 2 ? current + 1 : current;
-        });
 
     return (
         <Container>
-            <Stepper active={active}>
-                <Stepper.Step label="Upload" description="Upload Project files">
-                    <Dropzone onDrop={onDrop} mih={220} loading={saving}>
-                        <Group justify="center" gap="xl" mih={220} style={{pointerEvents: 'none'}}>
-                            <Dropzone.Accept>
-                                <IconUpload
-                                    style={{width: rem(52), height: rem(52), color: 'var(--mantine-color-blue-6)'}}
-                                    stroke={1.5}
-                                />
-                            </Dropzone.Accept>
-                            <Dropzone.Reject>
-                                <IconX
-                                    style={{width: rem(52), height: rem(52), color: 'var(--mantine-color-red-6)'}}
-                                    stroke={1.5}
-                                />
-                            </Dropzone.Reject>
-                            <Dropzone.Idle>
-                                <IconPhoto
-                                    style={{width: rem(52), height: rem(52), color: 'var(--mantine-color-dimmed)'}}
-                                    stroke={1.5}
-                                />
-                            </Dropzone.Idle>
+            <Dropzone onDrop={onDrop} mih={220} loading={saving}>
+                <Group justify="center" gap="xl" mih={220} style={{pointerEvents: 'none'}}>
+                    <Dropzone.Accept>
+                        <IconUpload
+                            style={{width: rem(52), height: rem(52), color: 'var(--mantine-color-blue-6)'}}
+                            stroke={1.5}
+                        />
+                    </Dropzone.Accept>
+                    <Dropzone.Reject>
+                        <IconX
+                            style={{width: rem(52), height: rem(52), color: 'var(--mantine-color-red-6)'}}
+                            stroke={1.5}
+                        />
+                    </Dropzone.Reject>
+                    <Dropzone.Idle>
+                        <IconPhoto
+                            style={{width: rem(52), height: rem(52), color: 'var(--mantine-color-dimmed)'}}
+                            stroke={1.5}
+                        />
+                    </Dropzone.Idle>
 
-                            <div>
-                                <Text size="xl" inline>
-                                    Drag images here or click to select files
-                                </Text>
-                                <Text size="sm" c="dimmed" inline mt={7}>
-                                    Attach as many files as you like, each file should not exceed 5mb
-                                </Text>
-                            </div>
-                        </Group>
-                    </Dropzone>
-                </Stepper.Step>
-                <Stepper.Step label="Configuration" description="Configure Project">
-                    <h1>{project?.name}</h1>
-                    <ProjectForm project={project} onProjectChange={onSave}/>
-                </Stepper.Step>
-                <Stepper.Step label="Done" description="Enjoy your project">
-                    <Text>Enjoy :)</Text>
-                </Stepper.Step>
-            </Stepper>
+                    <div>
+                        <Text size="xl" inline>
+                            Drag images here or click to select files
+                        </Text>
+                        <Text size="sm" c="dimmed" inline mt={7}>
+                            Attach as many files as you like, each file should not exceed 5mb
+                        </Text>
+                    </div>
+                </Group>
+            </Dropzone>
+
+            <ProjectForm project={emptyProject} onProjectChange={onSave} avoidSave={true}/>
         </Container>
     );
 }


### PR DESCRIPTION
Not an amazing PR but I wanted to have a working UI that goes with https://github.com/Maker-Management-Platform/agent/pull/23

This will change the UI so there are no steps anymore. All the info is introduced into one screen and only 1 HTTP call is done to the server.

After creation, the user is redirected to the project screen.

There are some things we should expand a bit. For example would be great to have the list of uploaded files shown (now it doesn't show anything) and maybe be able to select the main image from that list too.